### PR TITLE
Fixes two subject / state error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v0.0.7 (2020-12-12)
+
+### Bug fixes
+
+* Fixes in `optspace.py` function `rank_estimate` and  `factorization.py` function `tenals`
+    * fixes two subject/state tensor
+    * added test in `test_method.py` for two subject or state tensor 
+
 v0.0.6 (2020-09-27)
 
 ### Features

--- a/gemelli/__init__.py
+++ b/gemelli/__init__.py
@@ -6,4 +6,4 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"

--- a/gemelli/factorization.py
+++ b/gemelli/factorization.py
@@ -531,6 +531,9 @@ def tenals(tensor,
             total_nonzeros = np.count_nonzero(mask[i, :, :].copy())
             n_, m_ = obs_tmp.shape
             eps_tmp = total_nonzeros / np.sqrt(n_ * m_)
+            if min(obs_tmp.shape) <= 2:
+                # two-subjects/time is already low-rank
+                continue
             if rank_estimate(obs_tmp, eps_tmp) >= (min(obs_tmp.shape) - 1):
                 warnings.warn('A component of your data may be high-rank.',
                               RuntimeWarning)

--- a/gemelli/optspace.py
+++ b/gemelli/optspace.py
@@ -406,7 +406,6 @@ def grassmann_manifold_two(U, step_size, n_components):
 
 def rank_estimate(obs, eps, k=20, lam=0.05,
                   min_rank=3, max_iter=5000):
-
     """
     This function estimates the rank of a
     sparse matrix (i.e. with missing values).
@@ -440,9 +439,11 @@ def rank_estimate(obs, eps, k=20, lam=0.05,
            Conference on Communication, Control,
            and Computing (Allerton) 1216–1222 (2009).
     """
-
     # dim. of the data
     n, m = obs.shape
+    # ensure rank worth estimating
+    if min(n, m) <= 2:
+        return min_rank
     # get N-singular values
     s = svds(obs,  min(k, n, m) - 1, which='LM',
              return_singular_vectors=False)[::-1]


### PR DESCRIPTION
There is a bug in the rank estimation when the minimum shape of the input table is less than 3. See issue #38 & #39.

This PR fixes that bug by not estimating a table rank with less than 3 samples. Also, added additional tests to ensure two-state/subject does not break tensor factorization in the future. 