### PR TITLE
bug fix for phylo RPCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v0.0.8 (2022-03-28)
+
+### Bug fixes
+
+* Fixes in `rpca.py` function
+    * fixes bug that passes QIIME2 Metadata instead of the expected pandas dataframe
+        * see issue #57
+
 v0.0.7 (2022-01-19)
 
 ### Features [stable]

--- a/gemelli/__init__.py
+++ b/gemelli/__init__.py
@@ -6,4 +6,4 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/gemelli/rpca.py
+++ b/gemelli/rpca.py
@@ -78,6 +78,7 @@ def phylogenetic_rpca_with_taxonomy(
     be run QIIME2 versions of gemelli. Outside of QIIME2
     please use phylogenetic_rpca.
     """
+
     output = phylogenetic_rpca(table=table,
                                phylogeny=phylogeny,
                                taxonomy=taxonomy,
@@ -237,6 +238,10 @@ def phylogenetic_rpca(table: biom.Table,
 
     """
 
+    # validate the metadata using q2 as a wrapper
+    if taxonomy is not None and not isinstance(taxonomy,
+                                               pd.DataFrame):
+        taxonomy = taxonomy.to_dataframe()
     # use helper to process table
     table = rpca_table_processing(table,
                                   min_sample_count,


### PR DESCRIPTION
When using QIIME2 phylogenic RPCA, the taxonomy was being based as a QIIME2 Metadata instead of a pandas data frame (fixes issue #57). This adds a fix that is already in CTF but was missing in RPCA after the last version merge. 

This will move Gemelli to version 0.0.8, to cover this bug that would break use in QIIME2. 